### PR TITLE
Move to master branch for TSMP2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,9 +15,9 @@
 	url = https://github.com/HPSCTerrSys/namelist_oasis3-mct_TSMP2-real-template.git
 	branch = master
 [submodule "src/TSMP2"]
-        path = src/TSMP2
-        url = https://github.com/HPSCTerrSys/TSMP2.git
-        branch = dev_frontend
+	path = src/TSMP2
+	url = https://github.com/HPSCTerrSys/TSMP2.git
+	branch = master
 [submodule "dta/geo/icon"]
 	path = dta/geo/icon
 	url = https://icg4geo.icg.kfa-juelich.de/ExternalReposPublic/tsmp2-static-files/extpar_icon_cordex-eur-11u.git


### PR DESCRIPTION
I am pretty sure this should be `master` and this would fix <https://gitlab.jsc.fz-juelich.de/HPSCTerrSys/tsmp-internal-development-tracking/-/issues/111>.

I also replaced the 8-spaces with tab characters, to be consistent with the rest of the file.