### PR TITLE
Add PDAF to workflow engine

### DIFF
--- a/ctl/pre_ctl/pre_config.sh
+++ b/ctl/pre_ctl/pre_config.sh
@@ -56,6 +56,42 @@ echo "List of forcing files: "${listfrcfile[@]}
 
 fi
 
+####################
+# PDAF
+####################
+if [[ "${modelid}" == *pdaf* ]]; then
+
+parse_config_file ${conf_file} "pre_config_pdaf"
+
+# ---------------------------------------------------------------------------
+# Perturb atmospheric forcing
+# ---------------------------------------------------------------------------
+num_ensemble=${num_ensemble:-50}
+
+if [[ "${modelid}" == *clm* ]]; then
+
+lsmforcpertsrc_dir=${lsmforcpertsrc_dir:-${ctl_dir}/../src/eCLM_atmforcing/mkperturb}
+eclmfrc_dir=${eclmfrc_dir:-${frc_dir}/eclm/forcing/}
+pdaffrc_dir=${pdaffrc_dir:-${eclmfrc_dir}}
+
+check_var_def pre_config_pdaf_env $(find ${lsmforcpertsrc_dir}/../ -type f -name "*sh") "Using environment file "
+
+pyvenv_pre_config_pdaf=${pyvenv_pre_config_pdaf:-${ctl_dir}/virtualenvs/pyenv_pre_config_pdaf}
+
+# load environment
+source ${pre_config_pdaf_env}
+
+# create virtual env if it does not exist yet
+if [ ! -d "${pyvenv_pre_config_pdaf}" ]; then
+   echo "Virtual env not found at ${pyvenv_pre_config_pdaf}, installing "
+   python -m venv ${pyvenv_pre_config_pdaf}
+   source ${pyvenv_pre_config_pdaf}/bin/activate
+   pip install ${ctl_dir}/../src/eCLM_atmforcing/
+   deactivate
+fi
+
+fi # clm
+fi # pdaf
 
 if ${debugmode}; then
 

--- a/ctl/pre_ctl/pre_run.sh
+++ b/ctl/pre_ctl/pre_run.sh
@@ -41,7 +41,44 @@ for yyyymm in "${listfrcfile[@]}"; do
 done
 unset yyyymm year month
 
-fi
+fi #eclm
+
+if [[ "${modelid}" == *pdaf* ]]; then
+if [[ "${modelid}" == *clm* ]]; then
+
+cd "${lsmforcpertsrc_dir}"
+
+# load environment
+source ${pre_config_pdaf_env}
+source ${pyvenv_pre_config_pdaf}/bin/activate
+
+# list contain dates needed for forcing
+for yyyymm in "${listfrcfile[@]}"; do
+   year="${yyyymm%%-*}"
+   month="${yyyymm#*-}"
+
+   (
+      exec srun --exclusive -n 1 python perturb_forcings.py \
+       --years "${year}" \
+       --months "${month}" \
+       --num-ensemble ${num_ensemble} \
+       --fdir ${eclmfrc_dir} \
+       --outdir ${pdaffrc_dir}
+   ) &
+
+   # cap concurrent jobs at npnode (cores/tasks per node)
+   while (( $(jobs -rp | wc -l) >= npnode )); do
+      wait -n
+   done
+
+done
+wait
+unset yyyymm year month
+deactivate
+
+
+fi #eclm 
+fi #pdaf
 
 } # pre_run
 


### PR DESCRIPTION
Plan: Introduce PDAF as a `modelid` in the workflow engine in the different steps:

- Initialization (run by user before starting WFE, possibly also integrated somewhere)
  - provide input files ("common"/"cesm")
  - provide static files, possibly perturbed
  - provide parameter files, possibly perturbed
  - provide the case namelist files and stream files (single case, best in a repository / based on template)
  - provide TSMP-PDAF control file `enkfpf.par` [HPSCTerrSys/PDAF_input-file-generator](https://github.com/HPSCTerrSys/PDAF_input-file-generator)
  - provide observation files [HPSCTerrSys/PDAF_observation-file-generator](https://github.com/HPSCTerrSys/PDAF_observation-file-generator)

- Preprocessing (`pre`)
  - atmospheric forcing generation (via CLM-modelid), need to check that this works together with perturbation step
  - atmospheric forcing perturbation using [HPSCTerrSys/eCLM_atm-forcing-generator](https://github.com/HPSCTerrSys/eCLM_atm-forcing-generator)
  - future, possibly: soil parameter perturbation, perturbation of further parameters, but currently this would be part of an initial step that needs to be present before the WFE starts

- Simulations (`sim`)
  - ensemble namelist creation could be part of `sim_config` or initialization
  - jobscript needs to get `tsmp-pdaf` run-command option

- Postprocessing (`pos`) -> future

- Visualization (`vis`) -> future